### PR TITLE
CICD: Fix bad auto bump version

### DIFF
--- a/.github/workflows/release.sh
+++ b/.github/workflows/release.sh
@@ -15,15 +15,15 @@ TAG_PATCH=""
 
 WARNINGS=""
 
-if grep -q "^MAJOR" CHANGELOG; then
+if [[ "$(git show --pretty=format:%s --grep '^MAJOR' "$LAST_TAG..HEAD")" == "" ]]; then
     TAG_MAJOR=$((LAST_TAG_MAJOR + 1))
     TAG_MINOR="0"
     TAG_PATCH="0"
-elif grep -q "^MINOR" CHANGELOG; then
+elif [[ "$(git show --pretty=format:%s --grep '^MINOR' "$LAST_TAG..HEAD")" == "" ]]; then
     TAG_MAJOR=$((LAST_TAG_MAJOR + 0))
     TAG_MINOR=$((LAST_TAG_MINOR + 1))
     TAG_PATCH="0"
-elif grep -q "^PATCH" CHANGELOG; then
+elif [[ "$(git show --pretty=format:%s --grep '^PATCH' "$LAST_TAG..HEAD")" == "" ]]; then
     TAG_MAJOR=$((LAST_TAG_MAJOR + 0))
     TAG_MINOR=$((LAST_TAG_MINOR + 0))
     TAG_PATCH=$((LAST_TAG_PATCH + 1))
@@ -42,3 +42,4 @@ gh release create "$TAG"           \
   --target main
 
 echo "release_tag=$TAG" >> $GITHUB_OUTPUT
+echo "$WARNINGS"


### PR DESCRIPTION
<!-- This is a template message
     You will need to mark input boxes after clicking on
     create new pull request so just fill the blank.
     That means you don't need to touch the third categories
     because you fill mark them after pr creation
-->

<!-- Will be filled after creation -->
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines | -> no, but there is no issue
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Norm of the code has been respected

<!-- Will be filled after creation -->
* **In what state is your pull request?**
- [x] Ready to merge / Waiting a reviwer to see my work.
- [ ] Work In Progress (WIP) / My work is not finish but i want daily reviews. (Draft)
- [ ] CI Review / I want to see what the CI thinks of my work.
- [ ] Need feedback / Just to have feedback on what i produced. (May not be merged)

<!-- Will be filled after creation -->
* **What kind of change does this PR introduce?** (You can choose multiple)
- [x] Bug fix
- [ ] Feature request
- [ ] New / Updated documentation
- [ ] Testing CI ( Make the pull request in draft mode)

* **What is the current behavior?** (link an issue based on the kind of change this pr introduce)

https://x-r-g-b.atlassian.net/browse/RB-33?atlOrigin=eyJpIjoiNjAwMGZlNjBiMTBhNDUzN2JmNjNhMDgxMGI0Mjc2MDUiLCJwIjoiaiJ9


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
