### PR TITLE
ECS: Add now useless entities outside the window are destroyed

### DIFF
--- a/assets/Json/parallaxData.json
+++ b/assets/Json/parallaxData.json
@@ -2,8 +2,8 @@
     "parallax": [
         {
             "spritePath": "assets/Map/preview.png",
-            "width": 100,
-            "height": 100,
+            "width": 100.0,
+            "height": 100.0,
             "position": {
                 "x": 0.0,
                 "y": 0.0
@@ -23,7 +23,7 @@
                 "y": 20.0
             },
             "velocity" : {
-                "speedX" : -0.3,
+                "speedX" : -0.8,
                 "speedY" :0.0
             },
             "rect" : {

--- a/src/Client/Systems/Events/EventsSystems.cpp
+++ b/src/Client/Systems/Events/EventsSystems.cpp
@@ -90,6 +90,7 @@ namespace Systems {
             Registry::getInstance().getComponents<Types::Velocity>().insertBack(velocity);
             Registry::getInstance().getComponents<Types::Health>().insertBack(health);
             Registry::getInstance().getComponents<Types::Damage>().insertBack(damage);
+            Registry::getInstance().getComponents<Types::Dead>().insertBack({std::nullopt});
             Registry::getInstance().setToFrontLayers(entityId);
         }
     }

--- a/src/ECS/Systems/Systems.cpp
+++ b/src/ECS/Systems/Systems.cpp
@@ -256,12 +256,13 @@ namespace Systems {
         }
     }
 
-    constexpr int outsideWindowTopLeft = 0;
+    constexpr int outsideWindowTopLeft  = 0;
     constexpr int outsideWindowBotRigth = 100;
 
     static bool isOutsideWindow(const Types::Position &position)
     {
-        if (position.x < outsideWindowTopLeft || position.x > outsideWindowBotRigth || position.y < outsideWindowTopLeft || position.y > outsideWindowBotRigth) {
+        if (position.x < outsideWindowTopLeft || position.x > outsideWindowBotRigth
+            || position.y < outsideWindowTopLeft || position.y > outsideWindowBotRigth) {
             return (true);
         }
         return (false);
@@ -269,13 +270,15 @@ namespace Systems {
 
     void manageOutsideWindowEntity(std::size_t /*unused*/, std::size_t /*unused*/)
     {
-        Registry::components<Types::Position> arrPosition = Registry::getInstance().getComponents<Types::Position>();
-        Registry::components<Types::Parallax> arrParallax = Registry::getInstance().getComponents<Types::Parallax>();
+        Registry::components<Types::Position> arrPosition =
+            Registry::getInstance().getComponents<Types::Position>();
+        Registry::components<Types::Parallax> arrParallax =
+            Registry::getInstance().getComponents<Types::Parallax>();
         Registry::components<Types::Dead> arrDead = Registry::getInstance().getComponents<Types::Dead>();
 
         std::vector<std::size_t> ids = arrPosition.getExistingsId();
 
-        for (auto &id: ids) {
+        for (auto &id : ids) {
             if (!arrParallax.exist(id)) {
                 if (isOutsideWindow(arrPosition[id])) {
                     executeDeathFunction(id, arrDead);
@@ -332,7 +335,6 @@ namespace Systems {
             }
         }
     }
-
 
     const std::string playerFile = "assets/Json/playerData.json";
 

--- a/src/ECS/Systems/Systems.cpp
+++ b/src/ECS/Systems/Systems.cpp
@@ -256,13 +256,12 @@ namespace Systems {
         }
     }
 
-    constexpr int outsideWindowTopLeft  = 0;
-    constexpr int outsideWindowBotRigth = 100;
+    constexpr float outsideWindowTopLeft  = -25.0F;
+    constexpr float outsideWindowBotRigth = 125.0F;
 
-    static bool isOutsideWindow(const Types::Position &position)
+    static bool isOutsideWindow(const Types::Position &pos)
     {
-        if (position.x < outsideWindowTopLeft || position.x > outsideWindowBotRigth
-            || position.y < outsideWindowTopLeft || position.y > outsideWindowBotRigth) {
+        if (pos.x < outsideWindowTopLeft || pos.x > outsideWindowBotRigth || pos.y < outsideWindowTopLeft || pos.y > outsideWindowBotRigth) {
             return (true);
         }
         return (false);
@@ -274,14 +273,13 @@ namespace Systems {
             Registry::getInstance().getComponents<Types::Position>();
         Registry::components<Types::Parallax> arrParallax =
             Registry::getInstance().getComponents<Types::Parallax>();
-        Registry::components<Types::Dead> arrDead = Registry::getInstance().getComponents<Types::Dead>();
 
         std::vector<std::size_t> ids = arrPosition.getExistingsId();
 
         for (auto &id : ids) {
             if (!arrParallax.exist(id)) {
                 if (isOutsideWindow(arrPosition[id])) {
-                    executeDeathFunction(id, arrDead);
+                    Registry::getInstance().removeEntity(id);
                 }
             }
         }

--- a/src/ECS/Systems/Systems.cpp
+++ b/src/ECS/Systems/Systems.cpp
@@ -256,6 +256,48 @@ namespace Systems {
         }
     }
 
+    constexpr int outsideWindowTopLeft = 0;
+    constexpr int outsideWindowBotRigth = 100;
+
+    static bool isOutsideWindow(const Types::Position &position)
+    {
+        if (position.x < outsideWindowTopLeft || position.x > outsideWindowBotRigth || position.y < outsideWindowTopLeft || position.y > outsideWindowBotRigth) {
+            return (true);
+        }
+        return (false);
+    }
+
+    void manageOutsideWindowEntity(std::size_t /*unused*/, std::size_t /*unused*/)
+    {
+        Registry::components<Types::Position> arrPosition = Registry::getInstance().getComponents<Types::Position>();
+        Registry::components<Types::Parallax> arrParallax = Registry::getInstance().getComponents<Types::Parallax>();
+        Registry::components<Types::Dead> arrDead = Registry::getInstance().getComponents<Types::Dead>();
+
+        std::vector<std::size_t> ids = arrPosition.getExistingsId();
+
+        for (auto &id: ids) {
+            if (!arrParallax.exist(id)) {
+                if (isOutsideWindow(arrPosition[id])) {
+                    executeDeathFunction(id, arrDead);
+                }
+            }
+        }
+    }
+
+    void deathChecker(std::size_t /*unused*/, std::size_t /*unused*/)
+    {
+        Registry::components<Types::Health> arrHealth =
+            Registry::getInstance().getComponents<Types::Health>();
+        Registry::components<Types::Dead> arrDead = Registry::getInstance().getComponents<Types::Dead>();
+
+        std::vector<std::size_t> ids = arrHealth.getExistingsId();
+        for (auto itIds = ids.begin(); itIds != ids.end(); itIds++) {
+            if (arrHealth.exist(*itIds) && arrHealth[*itIds].hp <= 0 && arrDead.exist(*itIds)) {
+                executeDeathFunction(*itIds, arrDead);
+            }
+        }
+    }
+
     static void resetParallaxPosition(
         std::size_t id,
         Registry::components<Types::InitialPosition> &arrInitialPos,
@@ -291,19 +333,6 @@ namespace Systems {
         }
     }
 
-    void deathChecker(std::size_t /*unused*/, std::size_t /*unused*/)
-    {
-        Registry::components<Types::Health> arrHealth =
-            Registry::getInstance().getComponents<Types::Health>();
-        Registry::components<Types::Dead> arrDead = Registry::getInstance().getComponents<Types::Dead>();
-
-        std::vector<std::size_t> ids = arrHealth.getExistingsId();
-        for (auto itIds = ids.begin(); itIds != ids.end(); itIds++) {
-            if (arrHealth.exist(*itIds) && arrHealth[*itIds].hp <= 0 && arrDead.exist(*itIds)) {
-                executeDeathFunction(*itIds, arrDead);
-            }
-        }
-    }
 
     const std::string playerFile = "assets/Json/playerData.json";
 
@@ -351,6 +380,7 @@ namespace Systems {
             moveEntities,
             debugCollisionRect,
             deathChecker,
+            manageOutsideWindowEntity,
             manageParallax};
     }
 #else
@@ -363,6 +393,7 @@ namespace Systems {
             entitiesCollision,
             moveEntities,
             deathChecker,
+            manageOutsideWindowEntity,
             manageParallax};
     }
 #endif

--- a/src/ECS/Systems/Systems.cpp
+++ b/src/ECS/Systems/Systems.cpp
@@ -260,7 +260,8 @@ namespace Systems {
 
     static bool isOutsideWindow(const Types::Position &pos)
     {
-        if (pos.x < outsideWindowTopLeft || pos.x > outsideWindowBotRigth || pos.y < outsideWindowTopLeft || pos.y > outsideWindowBotRigth) {
+        if (pos.x < outsideWindowTopLeft || pos.x > outsideWindowBotRigth || pos.y < outsideWindowTopLeft
+            || pos.y > outsideWindowBotRigth) {
             return (true);
         }
         return (false);


### PR DESCRIPTION
MINOR

<!-- This is a template message
     You will need to mark input boxes after clicking on
     create new pull request so just fill the blank.
     That means you don't need to touch the third categories
     because you fill mark them after pr creation
-->

<!-- Will be filled after creation -->
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Norm of the code has been respected

<!-- Will be filled after creation -->
* **In what state is your pull request?**
- [x] Ready to merge / Waiting a reviwer to see my work.
- [ ] Work In Progress (WIP) / My work is not finish but i want daily reviews. (Draft)
- [ ] CI Review / I want to see what the CI thinks of my work.
- [ ] Need feedback / Just to have feedback on what i produced. (May not be merged)

<!-- Will be filled after creation -->
* **What kind of change does this PR introduce?** (You can choose multiple)
- [ ] Bug fix
- [x] Feature request
- [ ] New / Updated documentation
- [ ] Testing CI ( Make the pull request in draft mode)

* **What is the current behavior?** (link an issue based on the kind of change this pr introduce)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:
