### PR TITLE
NITWORK: Fix packet id doesn't need to change if he's resent

### DIFF
--- a/docs/network/rfc/RFC.md
+++ b/docs/network/rfc/RFC.md
@@ -295,7 +295,8 @@ Table of Contents
 2.2.2.2.    READY
 
     The Client must send a ready action to enter/start the game.
-    The Server respond to this action with a ready action.
+    The Server respond to this action by sending a start wave action, only if
+    all the clients are ready
 
 2.2.2.2.1.  Client
 

--- a/src/Nitwork/ANitwork.cpp
+++ b/src/Nitwork/ANitwork.cpp
@@ -188,6 +188,7 @@ namespace Nitwork {
                         "NITWORK: packet not found: " + std::to_string(header.last_id_received - index));
                     continue;
                 }
+                packet->isResend = true;
                 addPacketToSend(*packet);
             }
         }

--- a/src/Nitwork/ANitwork.cpp
+++ b/src/Nitwork/ANitwork.cpp
@@ -314,11 +314,6 @@ namespace Nitwork {
         return lastId;
     }
 
-    const boost::asio::ip::udp::endpoint &ANitwork::getEndpointSender()
-    {
-        return _senderEndpoint;
-    }
-
     void ANitwork::addPacketToSend(const Packet &packet)
     {
         std::lock_guard<std::mutex> lock(_outputQueueMutex);

--- a/src/Nitwork/ANitwork.cpp
+++ b/src/Nitwork/ANitwork.cpp
@@ -188,7 +188,7 @@ namespace Nitwork {
                         "NITWORK: packet not found: " + std::to_string(header.last_id_received - index));
                     continue;
                 }
-                packet->isResend = true;
+                packet->setIsResend(true);
                 addPacketToSend(*packet);
             }
         }

--- a/src/Nitwork/ANitwork.hpp
+++ b/src/Nitwork/ANitwork.hpp
@@ -45,9 +45,9 @@ namespace Nitwork {
                 }
                 T data = std::any_cast<T>(packet.body);
                 if (!packet.getIsResend()) {
-                    packet.id      = id;
-                    auto oldHeader = static_cast<struct header_s>(data.header);
-                    struct header_s newHeader      = {
+                    packet.id                 = id;
+                    auto oldHeader            = static_cast<struct header_s>(data.header);
+                    struct header_s newHeader = {
                         HEADER_CODE1,
                         getIdsReceived(packet.endpoint),
                         getLastIdsReceived(packet.endpoint),

--- a/src/Nitwork/ANitwork.hpp
+++ b/src/Nitwork/ANitwork.hpp
@@ -43,9 +43,9 @@ namespace Nitwork {
                     Logger::error("NITWORK: Package too big");
                     return;
                 }
-                T data      = std::any_cast<T>(packet.body);
+                T data = std::any_cast<T>(packet.body);
                 if (!packet.getIsResend()) {
-                    packet.id   = id;
+                    packet.id      = id;
                     auto newHeader = static_cast<struct header_s>(data.header);
                     newHeader      = {
                         HEADER_CODE1,

--- a/src/Nitwork/ANitwork.hpp
+++ b/src/Nitwork/ANitwork.hpp
@@ -46,13 +46,13 @@ namespace Nitwork {
                 T data = std::any_cast<T>(packet.body);
                 if (!packet.getIsResend()) {
                     packet.id      = id;
-                    auto newHeader = static_cast<struct header_s>(data.header);
-                    newHeader      = {
+                    auto oldHeader = static_cast<struct header_s>(data.header);
+                    struct header_s newHeader      = {
                         HEADER_CODE1,
                         getIdsReceived(packet.endpoint),
                         getLastIdsReceived(packet.endpoint),
                         id,
-                        newHeader.nb_action,
+                        oldHeader.nb_action,
                         HEADER_CODE2};
                     data.header = newHeader;
                 }

--- a/src/Nitwork/ANitwork.hpp
+++ b/src/Nitwork/ANitwork.hpp
@@ -27,6 +27,7 @@ namespace Nitwork {
             void operator=(const ANitwork &&) = delete;
 
             void stop() override;
+
         protected:
             ANitwork();
             // start the NitworkServer

--- a/src/Nitwork/ANitwork.hpp
+++ b/src/Nitwork/ANitwork.hpp
@@ -43,17 +43,19 @@ namespace Nitwork {
                     Logger::error("NITWORK: Package too big");
                     return;
                 }
-                packet.id   = id;
                 T data      = std::any_cast<T>(packet.body);
-                auto header = static_cast<struct header_s>(data.header);
-                header      = {
-                    HEADER_CODE1,
-                    getIdsReceived(packet.endpoint),
-                    getLastIdsReceived(packet.endpoint),
-                    id,
-                    header.nb_action,
-                    HEADER_CODE2};
-                data.header = header;
+                if (!packet.isResend) {
+                    packet.id   = id;
+                    auto header = static_cast<struct header_s>(data.header);
+                    header      = {
+                        HEADER_CODE1,
+                        getIdsReceived(packet.endpoint),
+                        getLastIdsReceived(packet.endpoint),
+                        id,
+                        header.nb_action,
+                        HEADER_CODE2};
+                    data.header = header;
+                }
 
                 _socket.async_send_to(
                     boost::asio::buffer(&data, sizeof(T)),

--- a/src/Nitwork/ANitwork.hpp
+++ b/src/Nitwork/ANitwork.hpp
@@ -44,17 +44,17 @@ namespace Nitwork {
                     return;
                 }
                 T data      = std::any_cast<T>(packet.body);
-                if (!packet.isResend) {
+                if (!packet.getIsResend()) {
                     packet.id   = id;
-                    auto header = static_cast<struct header_s>(data.header);
-                    header      = {
+                    auto newHeader = static_cast<struct header_s>(data.header);
+                    newHeader      = {
                         HEADER_CODE1,
                         getIdsReceived(packet.endpoint),
                         getLastIdsReceived(packet.endpoint),
                         id,
-                        header.nb_action,
+                        newHeader.nb_action,
                         HEADER_CODE2};
-                    data.header = header;
+                    data.header = newHeader;
                 }
 
                 _socket.async_send_to(

--- a/src/Nitwork/ANitwork.hpp
+++ b/src/Nitwork/ANitwork.hpp
@@ -43,7 +43,7 @@ namespace Nitwork {
                     Logger::error("NITWORK: Package too big");
                     return;
                 }
-                T data      = std::any_cast<T>(packet.body);
+                T data = std::any_cast<T>(packet.body);
                 if (!packet.isResend) {
                     packet.id   = id;
                     auto header = static_cast<struct header_s>(data.header);

--- a/src/Nitwork/ANitwork.hpp
+++ b/src/Nitwork/ANitwork.hpp
@@ -26,10 +26,12 @@ namespace Nitwork {
             void operator=(const ANitwork &)  = delete;
             void operator=(const ANitwork &&) = delete;
 
-            // start the NitworkServer
-            bool start(int port, int threadNb, int tick, const std::string &ip = "") override;
-
             void stop() override;
+        protected:
+            ANitwork();
+            // start the NitworkServer
+            bool start(int port, int threadNb, int tick, const std::string &ip = "") final;
+
             // send data to the endpoint with the given data
             template <typename T>
             void sendData(Packet &packet)
@@ -73,14 +75,10 @@ namespace Nitwork {
                     });
             }
 
-        protected:
-            ANitwork();
-
             /* Getters / Setters */
             n_idsReceived_t getIdsReceived(const boost::asio::ip::udp::endpoint &endpoint);
             n_id_t getLastIdsReceived(const boost::asio::ip::udp::endpoint &endpoint);
             n_id_t getPacketId(const boost::asio::ip::udp::endpoint &endpoint);
-            const boost::asio::ip::udp::endpoint &getEndpointSender();
             void addPacketToSend(const Packet &);
             void handlePacketIdsReceived(const struct header_s &header);
 

--- a/src/Nitwork/INitwork.hpp
+++ b/src/Nitwork/INitwork.hpp
@@ -56,11 +56,11 @@ namespace Nitwork {
                   endpoint(endpoint)
             {
             }
-
             n_id_t id = 0;
             n_actionType_t action;
             std::any body;
             boost::asio::ip::udp::endpoint endpoint;
+            bool isResend = false;
     };
 
     using actionSender = std::function<void(Packet &)>;

--- a/src/Nitwork/INitwork.hpp
+++ b/src/Nitwork/INitwork.hpp
@@ -56,8 +56,14 @@ namespace Nitwork {
                   endpoint(endpoint)
             {
             }
-            [[nodiscard]] bool getIsResend() const { return _isResend; }
-            void setIsResend(bool value) { _isResend = value; }
+            [[nodiscard]] bool getIsResend() const
+            {
+                return _isResend;
+            }
+            void setIsResend(bool value)
+            {
+                _isResend = value;
+            }
 
             n_id_t id = 0;
             n_actionType_t action;

--- a/src/Nitwork/INitwork.hpp
+++ b/src/Nitwork/INitwork.hpp
@@ -56,11 +56,16 @@ namespace Nitwork {
                   endpoint(endpoint)
             {
             }
+            [[nodiscard]] bool getIsResend() const { return _isResend; }
+            void setIsResend(bool value) { _isResend = value; }
+
             n_id_t id = 0;
             n_actionType_t action;
             std::any body;
             boost::asio::ip::udp::endpoint endpoint;
-            bool isResend = false;
+
+        private:
+            bool _isResend = false;
     };
 
     using actionSender = std::function<void(Packet &)>;

--- a/src/Nitwork/Nitwork.h
+++ b/src/Nitwork/Nitwork.h
@@ -16,7 +16,7 @@
     #define ONE_SECOND 1000
     #define DEFAULT_THREAD_NB 4
     #define MAX_NB_ACTION 16
-    #define MAX_CLIENTS 4
+    #define MAX_CLIENTS 2
     #define HEADER_CODE1 '\x01'
     #define HEADER_CODE2 '\x03'
 

--- a/src/Nitwork/Nitwork.h
+++ b/src/Nitwork/Nitwork.h
@@ -16,7 +16,7 @@
     #define ONE_SECOND 1000
     #define DEFAULT_THREAD_NB 4
     #define MAX_NB_ACTION 16
-    #define MAX_CLIENTS 2
+    #define MAX_CLIENTS 4
     #define HEADER_CODE1 '\x01'
     #define HEADER_CODE2 '\x03'
 

--- a/src/Nitwork/Nitwork.h
+++ b/src/Nitwork/Nitwork.h
@@ -16,7 +16,6 @@
     #define ONE_SECOND 1000
     #define DEFAULT_THREAD_NB 4
     #define MAX_NB_ACTION 16
-    #define MAX_CLIENTS 4
     #define HEADER_CODE1 '\x01'
     #define HEADER_CODE2 '\x03'
 

--- a/src/Nitwork/NitworkClient.cpp
+++ b/src/Nitwork/NitworkClient.cpp
@@ -22,7 +22,7 @@ namespace Nitwork {
         return _instance;
     }
 
-    bool NitworkClient::start(int port, int threadNb, int tick, const std::string &ip)
+    bool NitworkClient::startClient(int port, const std::string &ip, int threadNb, int tick)
     {
         return ANitwork::start(port, threadNb, tick, ip);
     }

--- a/src/Nitwork/NitworkClient.hpp
+++ b/src/Nitwork/NitworkClient.hpp
@@ -22,11 +22,11 @@ namespace Nitwork {
             static NitworkClient &getInstance();
 
             using ANitwork::start;
-            bool start(
+            bool startClient(
                 int port,
+                const std::string &ip,
                 int threadNb          = DEFAULT_THREAD_NB,
-                int tick              = TICKS_PER_SECOND,
-                const std::string &ip = "") final;
+                int tick              = TICKS_PER_SECOND);
 
             // Messages creation methods
             void addInitMsg();

--- a/src/Nitwork/NitworkClient.hpp
+++ b/src/Nitwork/NitworkClient.hpp
@@ -25,8 +25,8 @@ namespace Nitwork {
             bool startClient(
                 int port,
                 const std::string &ip,
-                int threadNb          = DEFAULT_THREAD_NB,
-                int tick              = TICKS_PER_SECOND);
+                int threadNb = DEFAULT_THREAD_NB,
+                int tick     = TICKS_PER_SECOND);
 
             // Messages creation methods
             void addInitMsg();

--- a/src/Nitwork/NitworkServer.cpp
+++ b/src/Nitwork/NitworkServer.cpp
@@ -130,6 +130,10 @@ namespace Nitwork {
             Logger::info("Client not connected");
             return;
         }
+        if (_endpoints.size() < MAX_CLIENTS) {
+            Logger::info("Not enough clients");
+            return;
+        }
         addStarWaveMessage(endpoint, Types::Enemy::getEnemyNb());
         Systems::SystemManagersDirector::getInstance().getSystemManager(0).addSystem(Systems::initWave);
     }

--- a/src/Nitwork/NitworkServer.cpp
+++ b/src/Nitwork/NitworkServer.cpp
@@ -131,7 +131,7 @@ namespace Nitwork {
             return;
         }
         if (_endpoints.size() < MAX_CLIENTS) {
-            Logger::info("Not enough clients");
+            Logger::info("A new client is ready, waiting for others");
             return;
         }
         addStarWaveMessage(endpoint, Types::Enemy::getEnemyNb());

--- a/src/Nitwork/NitworkServer.cpp
+++ b/src/Nitwork/NitworkServer.cpp
@@ -22,9 +22,14 @@ namespace Nitwork {
         return _instance;
     }
 
-    bool NitworkServer::start(int port, int threadNb, int tick, const std::string &ip)
+    bool NitworkServer::startServer(
+        int port,
+        int nbPlayer,
+        int threadNb,
+        int tick)
     {
-        return ANitwork::start(port, threadNb, tick, ip);
+        _maxNbPlayer = nbPlayer;
+        return ANitwork::start(port, threadNb, tick, "");
     }
 
     bool NitworkServer::startNitworkConfig(int port, const std::string & /* unused */)
@@ -111,7 +116,7 @@ namespace Nitwork {
     void
     NitworkServer::handleInitMsg(const std::any & /* unused */, boost::asio::ip::udp::endpoint &endpoint)
     {
-        if (_endpoints.size() >= MAX_CLIENTS) {
+        if (_endpoints.size() >= _maxNbPlayer) {
             std::cerr << "Too many clients, can't add an other one" << std::endl;
             return;
         }
@@ -130,7 +135,7 @@ namespace Nitwork {
             Logger::info("Client not connected");
             return;
         }
-        if (_endpoints.size() < MAX_CLIENTS) {
+        if (_endpoints.size() < _maxNbPlayer) {
             Logger::info("A new client is ready, waiting for others");
             return;
         }

--- a/src/Nitwork/NitworkServer.cpp
+++ b/src/Nitwork/NitworkServer.cpp
@@ -22,11 +22,7 @@ namespace Nitwork {
         return _instance;
     }
 
-    bool NitworkServer::startServer(
-        int port,
-        int nbPlayer,
-        int threadNb,
-        int tick)
+    bool NitworkServer::startServer(int port, int nbPlayer, int threadNb, int tick)
     {
         _maxNbPlayer = nbPlayer;
         return ANitwork::start(port, threadNb, tick, "");

--- a/src/Nitwork/NitworkServer.hpp
+++ b/src/Nitwork/NitworkServer.hpp
@@ -24,8 +24,8 @@ namespace Nitwork {
             bool startServer(
                 int port,
                 int nbPlayer,
-                int threadNb          = DEFAULT_THREAD_NB,
-                int tick              = TICKS_PER_SECOND);
+                int threadNb = DEFAULT_THREAD_NB,
+                int tick     = TICKS_PER_SECOND);
 
             /* Messages creation methods */
             void addStarWaveMessage(boost::asio::ip::udp::endpoint &endpoint, n_id_t enemyId);

--- a/src/Nitwork/NitworkServer.hpp
+++ b/src/Nitwork/NitworkServer.hpp
@@ -21,11 +21,11 @@ namespace Nitwork {
 
             static NitworkServer &getInstance();
 
-            bool start(
+            bool startServer(
                 int port,
+                int nbPlayer,
                 int threadNb          = DEFAULT_THREAD_NB,
-                int tick              = TICKS_PER_SECOND,
-                const std::string &ip = "") final;
+                int tick              = TICKS_PER_SECOND);
 
             /* Messages creation methods */
             void addStarWaveMessage(boost::asio::ip::udp::endpoint &endpoint, n_id_t enemyId);
@@ -84,6 +84,7 @@ namespace Nitwork {
             // NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
             static NitworkServer _instance; // instance of the NitworkServer (singleton)
             // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+            unsigned int _maxNbPlayer = 0; // max number of players
             std::list<boost::asio::ip::udp::endpoint>
                 _endpoints; // A vector of endpoints which will be used to send the actions to the clients
                             // and identify them

--- a/src/main_client.cpp
+++ b/src/main_client.cpp
@@ -64,7 +64,7 @@ int main(int ac, char **av)
     }
     auto &sceneManager = Scene::SceneManager::getInstance();
     if (!Nitwork::NitworkClient::getInstance()
-             .start(std::stoi(av[2]), DEFAULT_THREAD_NB, TICKS_PER_SECOND, av[1])) {
+             .startClient(std::stoi(av[2]), av[1], DEFAULT_THREAD_NB, TICKS_PER_SECOND)) {
         return EXIT_EPITECH;
     }
     Nitwork::NitworkClient::getInstance().addInitMsg();

--- a/src/main_client.cpp
+++ b/src/main_client.cpp
@@ -5,23 +5,6 @@
 ** main
 */
 
-// #include "NitworkClient.hpp"
-//
-//  int main()
-//{
-//      const int port = 4242;
-//      Nitwork::NitworkClient::getInstance().start(port);
-//
-//      Nitwork::NitworkClient::getInstance().addInitMsg();
-//      Nitwork::NitworkClient::getInstance().addInitMsg();
-//      Nitwork::NitworkClient::getInstance().addInitMsg();
-//      Nitwork::NitworkClient::getInstance().addInitMsg();
-//      Nitwork::NitworkClient::getInstance().addReadyMsg();
-//      while (true) {};
-//      return 0;
-//  }
-
-#include <cstddef>
 #include "Logger.hpp"
 #include "NitworkClient.hpp"
 #include "Registry.hpp"
@@ -30,30 +13,30 @@
 
 constexpr int EXIT_EPITECH = 84;
 
-static bool checkArgs(int ac, char **av)
+static bool isNumber(const std::string &str)
+{
+    return std::all_of(str.begin(), str.end(), ::isdigit);
+}
+
+static bool checkArgs(int ac, const char **av)
 {
     if (ac != 3) {
         Logger::error("Usage: ./r-type_client <ip> <port>");
         return false;
     }
-    for (int i = 0; av[2][i] != '\0'; i++) {
-        if (av[2][i] < '0' || av[2][i] > '9') {
-            Logger::error("Invalid port");
-            return false;
-        }
-    }
-    if (std::stoi(av[2]) < 0 || std::stoi(av[2]) > 65535) {
-        Logger::error("Invalid port");
+    const std::vector<std::string> args(av + 1, av + ac);
+    if (args[0].empty()) {
+        Logger::error("Invalid ip");
         return false;
     }
-    if (av[1][0] == '\0') {
-        Logger::error("Invalid ip");
+    if (!isNumber(args[1]) || std::stoi(args[1]) < 0 || std::stoi(args[1]) > 65535) {
+        Logger::error("Invalid port");
         return false;
     }
     return true;
 }
 
-int main(int ac, char **av)
+int main(int ac, const char **av)
 {
 #ifndef NDEBUG
     Registry::getInstance().getLogger().setLogLevel(Logger::LogLevel::Debug);

--- a/src/main_server.cpp
+++ b/src/main_server.cpp
@@ -18,24 +18,31 @@ static void signalHandler(int signum)
     signal(SIGINT, SIG_DFL);
 }
 
-static bool checkArgs(int ac, const char **av)
+static bool isNumber(const std::string &str)
 {
-    if (ac != 2) {
-        Logger::error("Usage: ./r-type_server <port>");
-        return false;
-    }
-    if (av[1][0] == '\0') {
-        Logger::error("Invalid ip");
-        return false;
-    }
-    for (int i = 0; av[1][i] != '\0'; i++) {
-        if (av[1][i] < '0' || av[1][i] > '9') {
-            Logger::error("Invalid port");
+    for (auto c : str) {
+        if (c < '0' || c > '9') {
             return false;
         }
     }
-    if (std::stoi(av[1]) < PORT_MIN || std::stoi(av[1]) > PORT_MAX) {
-        Logger::error("Invalid port");
+    return true;
+}
+
+static bool checkArgs(int ac, const char **av)
+{
+    if (ac != 3) {
+        Logger::error("Usage: ./r-type_server <port> <playerNb>");
+        return false;
+    }
+    const std::vector<std::string> args(av + 1, av + ac);
+    for (const auto &arg : args) {
+        if (!isNumber(arg)) {
+            Logger::error("Invalid argument");
+            return false;
+        }
+    }
+    if (std::stoi(args[0]) < PORT_MIN || std::stoi(args[0]) > PORT_MAX || std::stoi(args[1]) < 1) {
+        Logger::error("Invalid port or playerNb");
         return false;
     }
     return true;
@@ -51,7 +58,7 @@ int main(int ac, const char **av)
         return EXIT_EPITECH;
     }
     Logger::info("Starting Server...");
-    if (!Nitwork::NitworkServer::getInstance().start(std::stoi(av[1]))) {
+    if (!Nitwork::NitworkServer::getInstance().startServer(std::stoi(av[1]), std::stoi(av[2]))) {
         return EXIT_EPITECH;
     }
     Systems::SystemManagersDirector::getInstance().addSystemManager(Systems::getECSSystems());

--- a/src/main_server.cpp
+++ b/src/main_server.cpp
@@ -20,12 +20,7 @@ static void signalHandler(int signum)
 
 static bool isNumber(const std::string &str)
 {
-    for (auto c : str) {
-        if (c < '0' || c > '9') {
-            return false;
-        }
-    }
-    return true;
+    return std::all_of(str.begin(), str.end(), ::isdigit);
 }
 
 static bool checkArgs(int ac, const char **av)

--- a/src/main_server.cpp
+++ b/src/main_server.cpp
@@ -32,7 +32,7 @@ static bool checkArgs(int ac, const char **av)
     const std::vector<std::string> args(av + 1, av + ac);
     for (const auto &arg : args) {
         if (!isNumber(arg)) {
-            Logger::error("Invalid argument");
+            Logger::error("Invalid argument: " + arg);
             return false;
         }
     }


### PR DESCRIPTION
PATCH

<!-- This is a template message
     You will need to mark input boxes after clicking on
     create new pull request so just fill the blank.
     That means you don't need to touch the third categories
     because you fill mark them after pr creation
-->

<!-- Will be filled after creation -->
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Norm of the code has been respected

<!-- Will be filled after creation -->
* **In what state is your pull request?**
- [x] Ready to merge / Waiting a reviwer to see my work.
- [ ] Work In Progress (WIP) / My work is not finish but i want daily reviews. (Draft)
- [ ] CI Review / I want to see what the CI thinks of my work.
- [ ] Need feedback / Just to have feedback on what i produced. (May not be merged)

<!-- Will be filled after creation -->
* **What kind of change does this PR introduce?** (You can choose multiple)
- [x] Bug fix
- [ ] Feature request
- [ ] New / Updated documentation
- [ ] Testing CI ( Make the pull request in draft mode)

* **What is the current behavior?** (link an issue based on the kind of change this pr introduce)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced a mechanism to handle packet resending more efficiently, improving network performance and reliability.
- New Feature: Updated the server-client action flow to ensure the game starts only when all clients are ready, enhancing the multiplayer experience.
- Refactor: Modified the `start` function in both `NitworkClient` and `NitworkServer` classes for better clarity and functionality. The `NitworkClient`'s `start` function now includes an optional IP parameter, and the `NitworkServer`'s `start` function includes a parameter for the maximum number of players.
- Bug Fix: Added checks to prevent the server from exceeding the maximum number of players and to prevent sending star wave messages when there are not enough clients connected.
- Documentation: Updated the RFC document to reflect the new action flow between the client and server.
- Refactor: Improved argument validation in the main server and client functions for better error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->