### PR TITLE
CLIENT-NETWORK: Add system receive broadcast position absolute

### DIFF
--- a/src/Client/Systems/Network/ClientNetwork.cpp
+++ b/src/Client/Systems/Network/ClientNetwork.cpp
@@ -166,6 +166,31 @@ namespace Systems {
         Systems::createMissile(position, missileType);
     }
 
+    void receiveBroadcastAbsolutePosition(std::any &any, boost::asio::ip::udp::endpoint & /* unused*/)
+    {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
+
+        const struct msgPositionAbsoluteBroadcast_s &msg = std::any_cast<struct msgPositionAbsoluteBroadcast_s>(any);
+        struct Types::Position position = {
+            static_cast<float>(msg.pos.x),
+            static_cast<float>(msg.pos.y),
+        };
+        auto &arrPos = Registry::getInstance().getComponents<Types::Position>();
+        auto &arrOtherPlayers = Registry::getInstance().getComponents<Types::OtherPlayer>();
+        auto ids = Registry::getInstance().getEntitiesByComponents({typeid(Types::Position), typeid(Types::OtherPlayer)});
+        auto otherPlayer = std::find_if(
+            ids.begin(),
+            ids.end(),
+            [&arrOtherPlayers, &msg](std::size_t id) {
+                return arrOtherPlayers[id].constId == msg.playerId;
+            });
+
+        if (otherPlayer == ids.end()) {
+            return;
+        }
+        arrPos[*otherPlayer] = position;
+    }
+
     std::vector<std::function<void(std::size_t, std::size_t)>> getNetworkSystems()
     {
         return {sendPositionRelative, sendPositionAbsolute};

--- a/src/Client/Systems/Network/ClientNetwork.cpp
+++ b/src/Client/Systems/Network/ClientNetwork.cpp
@@ -170,20 +170,19 @@ namespace Systems {
     {
         std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
 
-        const struct msgPositionAbsoluteBroadcast_s &msg = std::any_cast<struct msgPositionAbsoluteBroadcast_s>(any);
+        const struct msgPositionAbsoluteBroadcast_s &msg =
+            std::any_cast<struct msgPositionAbsoluteBroadcast_s>(any);
         struct Types::Position position = {
             static_cast<float>(msg.pos.x),
             static_cast<float>(msg.pos.y),
         };
-        auto &arrPos = Registry::getInstance().getComponents<Types::Position>();
+        auto &arrPos          = Registry::getInstance().getComponents<Types::Position>();
         auto &arrOtherPlayers = Registry::getInstance().getComponents<Types::OtherPlayer>();
-        auto ids = Registry::getInstance().getEntitiesByComponents({typeid(Types::Position), typeid(Types::OtherPlayer)});
-        auto otherPlayer = std::find_if(
-            ids.begin(),
-            ids.end(),
-            [&arrOtherPlayers, &msg](std::size_t id) {
-                return arrOtherPlayers[id].constId == msg.playerId;
-            });
+        auto ids              = Registry::getInstance().getEntitiesByComponents(
+            {typeid(Types::Position), typeid(Types::OtherPlayer)});
+        auto otherPlayer = std::find_if(ids.begin(), ids.end(), [&arrOtherPlayers, &msg](std::size_t id) {
+            return arrOtherPlayers[id].constId == msg.playerId;
+        });
 
         if (otherPlayer == ids.end()) {
             return;

--- a/src/Client/Systems/Network/ClientNetwork.hpp
+++ b/src/Client/Systems/Network/ClientNetwork.hpp
@@ -13,5 +13,6 @@ namespace Systems {
     void receiveNewAllie(std::any &any, boost::asio::ip::udp::endpoint &);
     void sendPositionRelative(std::size_t /* unused */, std::size_t /* unused */);
     void receiveNewBullet(std::any &any, boost::asio::ip::udp::endpoint &endpoint);
+    void receiveBroadcastAbsolutePosition(std::any &any, boost::asio::ip::udp::endpoint &endpoint);
     std::vector<std::function<void(std::size_t, std::size_t)>> getNetworkSystems();
 } // namespace Systems

--- a/src/Nitwork/NitworkClient.hpp
+++ b/src/Nitwork/NitworkClient.hpp
@@ -140,6 +140,17 @@ namespace Nitwork {
                             Systems::receiveNewBullet(any, endpoint);
                         }
                     }
+                },
+                {
+                    POSITION_ABSOLUTE_BROADCAST,
+                    {
+                        [this](actionHandler &handler, const struct header_s &header) {
+                            handleBody<struct msgPositionAbsolute_s>(handler, header);
+                        },
+                        [](std::any &any, boost::asio::ip::udp::endpoint &endpoint) {
+                            Systems::receiveBroadcastAbsolutePosition(any, endpoint);
+                        }
+                    }
                 }
             };
             std::map<

--- a/src/Nitwork/NitworkServer.hpp
+++ b/src/Nitwork/NitworkServer.hpp
@@ -161,7 +161,7 @@ namespace Nitwork {
                  }},
                 {POSITION_ABSOLUTE_BROADCAST,
                  [this](Packet &packet) {
-                     sendData<struct packetPositionAbsolute_s>(packet);
+                     sendData<struct packetPositionAbsoluteBroadcast_s>(packet);
                  }},
             };
     };


### PR DESCRIPTION
MINOR

<!-- This is a template message
     You will need to mark input boxes after clicking on
     create new pull request so just fill the blank.
     That means you don't need to touch the third categories
     because you fill mark them after pr creation
-->

<!-- Will be filled after creation -->
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Norm of the code has been respected

<!-- Will be filled after creation -->
* **In what state is your pull request?**
- [x] Ready to merge / Waiting a reviwer to see my work.
- [ ] Work In Progress (WIP) / My work is not finish but i want daily reviews. (Draft)
- [ ] CI Review / I want to see what the CI thinks of my work.
- [ ] Need feedback / Just to have feedback on what i produced. (May not be merged)

<!-- Will be filled after creation -->
* **What kind of change does this PR introduce?** (You can choose multiple)
- [ ] Bug fix
- [x] Feature request
- [ ] New / Updated documentation
- [ ] Testing CI ( Make the pull request in draft mode)

* **What is the current behavior?** (link an issue based on the kind of change this pr introduce)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Introduced real-time player position updates. This enhancement allows the system to receive and process broadcasted absolute position messages, updating the position of other players in the game in real-time. This feature enhances the multiplayer experience by providing accurate and up-to-date positioning information.
- Improvement: Enhanced thread safety when accessing player data. This update ensures that the game's performance remains stable and reliable, even when multiple processes are accessing and updating player positions simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->