### PR TITLE
Fix/rb 141 fix last release problem

### DIFF
--- a/src/Client/Systems/Events/EventsSystems.cpp
+++ b/src/Client/Systems/Events/EventsSystems.cpp
@@ -33,6 +33,7 @@ namespace Systems {
 
     void EventsSystems::playerMovement(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         Registry &registry                              = Registry::getInstance();
         Registry::components<Types::Position> arrPos    = registry.getComponents<Types::Position>();
         Registry::components<struct health_s> arrHealth = registry.getComponents<struct health_s>();
@@ -66,6 +67,7 @@ namespace Systems {
 
     void playerShootBullet(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         static const std::size_t waitTimeBullet           = 500;
         static const std::string soundPathShoot           = "assets/Audio/Sounds/laser.ogg";
         Registry &registry                                = Registry::getInstance();
@@ -107,6 +109,7 @@ namespace Systems {
 
     void EventsSystems::changeScene(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         if (Raylib::isKeyDown(Raylib::KeyboardKey::KB_J)) {
             auto &sceneManager = Scene::SceneManager::getInstance();
             if (sceneManager.getCurrentScene() == Scene::Scene::MAIN_GAME) {

--- a/src/Client/Systems/Graphic/AudioSystems.cpp
+++ b/src/Client/Systems/Graphic/AudioSystems.cpp
@@ -61,6 +61,7 @@ namespace Systems {
 
     void GraphicSystems::initAudio(std::size_t managerId, std::size_t systemId)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         constexpr float musicVolume = 0.60F;
         constexpr float soundVolume = 0.63F;
 

--- a/src/Client/Systems/Graphic/DeathSystems.cpp
+++ b/src/Client/Systems/Graphic/DeathSystems.cpp
@@ -32,6 +32,7 @@ namespace Systems {
 
     void DeathSystems::setEntityDeathFunction(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         Registry::components<Types::Dead> arrDead = Registry::getInstance().getComponents<Types::Dead>();
 
         std::vector<std::size_t> ids = arrDead.getExistingsId();

--- a/src/Client/Systems/Graphic/ParallaxSystems.cpp
+++ b/src/Client/Systems/Graphic/ParallaxSystems.cpp
@@ -44,6 +44,7 @@ namespace Systems::ParallaxSystems {
 
     void initParalax(std::size_t managerId, std::size_t systemId)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         std::vector<nlohmann::basic_json<>> parallaxData =
             Json::getInstance().getDataByJsonType("parallax", JsonType::DEFAULT_PARALLAX);
 

--- a/src/Client/Systems/Graphic/SpriteSystems.cpp
+++ b/src/Client/Systems/Graphic/SpriteSystems.cpp
@@ -83,6 +83,7 @@ namespace Systems {
 
     void GraphicSystems::rectIncrementation(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         Registry &registry                                = Registry::getInstance();
         Registry::components<Types::AnimRect> arrAnimRect = registry.getComponents<Types::AnimRect>();
         Registry::components<Types::Rect> arrRect         = registry.getComponents<Types::Rect>();
@@ -96,6 +97,7 @@ namespace Systems {
 
     void GraphicSystems::rectRenderer(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         Registry &registry                                = Registry::getInstance();
         Registry::components<Types::Position> arrPosition = registry.getComponents<Types::Position>();
         Registry::components<Types::RectangleShape> arrRect =
@@ -193,6 +195,7 @@ namespace Systems {
 
     void GraphicSystems::spriteRenderer(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         Registry &registry                                = Registry::getInstance();
         std::vector<std::vector<std::size_t>> backLayers  = registry.getBackLayers();
         std::vector<std::size_t> defaultLayer             = registry.getDefaultLayer();
@@ -209,6 +212,7 @@ namespace Systems {
 
     void GraphicSystems::createSprite(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         auto &arrSpriteDatas = Registry::getInstance().getComponents<Types::SpriteDatas>();
         auto &arrSprite      = Registry::getInstance().getComponents<Raylib::Sprite>();
 

--- a/src/Client/Systems/Graphic/TextSystems.cpp
+++ b/src/Client/Systems/Graphic/TextSystems.cpp
@@ -56,6 +56,7 @@ namespace Systems {
 
     void GraphicSystems::textRenderer(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         Registry::components<Raylib::Text> arrText = Registry::getInstance().getComponents<Raylib::Text>();
 
         std::vector<std::size_t> ids = arrText.getExistingsId();

--- a/src/Client/Systems/Network/ClientNetwork.cpp
+++ b/src/Client/Systems/Network/ClientNetwork.cpp
@@ -60,21 +60,20 @@ namespace Systems {
         const auto playerInit = std::any_cast<struct msgPlayerInit_s>(any);
 
         Logger::info("Your player id is: " + std::to_string(playerInit.playerId));
-        initPlayer(JsonType::DEFAULT_PLAYER, playerInit.playerId);
+        initPlayer(playerInit.playerId);
     }
 
     void receiveNewEnemy(std::any &any, boost::asio::ip::udp::endpoint & /* unused */)
     {
         std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         const auto newEnemy = std::any_cast<struct msgNewEnemy_s>(any);
-
-        Logger::debug("ROLLBACK RECREATE ENEMY !!!!!");
-        initEnemy(newEnemy.enemyInfos.type, {0.0, 0.0}, true, newEnemy.enemyInfos.id);
         Types::Position pos = {
             static_cast<float>(newEnemy.enemyInfos.pos.x),
             static_cast<float>(newEnemy.enemyInfos.pos.y)};
+
+        Logger::debug("ROLLBACK RECREATE ENEMY !!!!!");
+        initEnemy(newEnemy.enemyInfos.type, pos, true, newEnemy.enemyInfos.id);
         struct health_s hp = newEnemy.enemyInfos.life;
-        Registry::getInstance().getComponents<Types::Position>().insertBack(pos);
         Registry::getInstance().getComponents<struct health_s>().insertBack(hp);
     }
 
@@ -84,7 +83,7 @@ namespace Systems {
         const auto newAllie = std::any_cast<struct msgNewAllie_s>(any);
 
         Logger::info("New Ally created with id: " + std::to_string(newAllie.playerId));
-        initPlayer(JsonType::DEFAULT_PLAYER, newAllie.playerId, true);
+        initPlayer(newAllie.playerId, true);
     }
 
     void receiveRelativePosition(std::any &any, boost::asio::ip::udp::endpoint & /* unused */)

--- a/src/Client/Systems/Network/ClientNetwork.cpp
+++ b/src/Client/Systems/Network/ClientNetwork.cpp
@@ -45,10 +45,11 @@ namespace Systems {
 
     void handleStartWave(std::any &any, boost::asio::ip::udp::endpoint & /* unused */)
     {
-        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
+        auto &director = SystemManagersDirector::getInstance();
+        std::lock_guard<std::mutex> lock(director.mutex);
         const auto wave = std::any_cast<struct msgStartWave_s>(any);
         Types::Enemy::setEnemyNb(wave.enemyNb);
-        SystemManagersDirector::getInstance()
+            director
             .getSystemManager(static_cast<std::size_t>(Scene::SystemManagers::GAME))
             .addSystem(initWave);
         Logger::info("Wave started");

--- a/src/Client/Systems/Network/ClientNetwork.cpp
+++ b/src/Client/Systems/Network/ClientNetwork.cpp
@@ -49,8 +49,7 @@ namespace Systems {
         std::lock_guard<std::mutex> lock(director.mutex);
         const auto wave = std::any_cast<struct msgStartWave_s>(any);
         Types::Enemy::setEnemyNb(wave.enemyNb);
-            director
-            .getSystemManager(static_cast<std::size_t>(Scene::SystemManagers::GAME))
+        director.getSystemManager(static_cast<std::size_t>(Scene::SystemManagers::GAME))
             .addSystem(initWave);
         Logger::info("Wave started");
     }

--- a/src/ECS/Json.hpp
+++ b/src/ECS/Json.hpp
@@ -65,6 +65,32 @@ class Json {
             return jsonData[index].get<T>();
         }
 
+        template <typename T>
+        T getDataByJsonType(const std::string &index, JsonType dataType)
+        {
+            return getDataFromJson<T>(_jsonDatas[dataType], index);
+        }
+
+        template <typename T>
+        T getDataByVector(const std::vector<std::string> &indexes, JsonType dataType)
+        {
+            auto datas = getDataByJsonType(dataType);
+            auto begin = indexes.begin();
+
+            if (indexes.empty()) {
+                Logger::fatal(std::string("(getDataByVector<T>): empty list"));
+                throw std::runtime_error("Json error");
+            }
+            for (; begin + 1 != indexes.end(); begin++) {
+                if (datas[*begin] == nullptr) {
+                    Logger::fatal(std::string("(getDataByVector<T>) Key : " + *begin + " is not valid"));
+                    throw std::runtime_error("Json error");
+                }
+                datas = datas[*begin];
+            }
+            return getDataFromJson<T>(datas, *(indexes.end() - 1));
+        }
+
     private:
         Json()  = default;
         ~Json() = default;

--- a/src/ECS/Systems/Managers/SystemManager.cpp
+++ b/src/ECS/Systems/Managers/SystemManager.cpp
@@ -50,8 +50,6 @@ namespace Systems {
 
     void SystemManager::addSystem(std::function<void(std::size_t, std::size_t)> sys)
     {
-        std::lock_guard<std::mutex> lock(SystemManagersDirector::getInstance().mutex);
-
         if (!_modified) {
             _modified = true;
         }
@@ -60,8 +58,6 @@ namespace Systems {
 
     void SystemManager::removeSystem(std::size_t id)
     {
-        std::lock_guard<std::mutex> lock(SystemManagersDirector::getInstance().mutex);
-
         if (!_modified) {
             _modified = true;
         }
@@ -70,16 +66,12 @@ namespace Systems {
 
     void SystemManager::resetChanges()
     {
-        std::lock_guard<std::mutex> lock(SystemManagersDirector::getInstance().mutex);
-
         _modified        = false;
         _modifiedSystems = _originalSystems;
     }
 
     std::vector<std::function<void(std::size_t, std::size_t)>> &SystemManager::getSystems()
     {
-        std::lock_guard<std::mutex> lock(SystemManagersDirector::getInstance().mutex);
-
         if (_modified) {
             return _modifiedSystems;
         }

--- a/src/ECS/Systems/Systems.cpp
+++ b/src/ECS/Systems/Systems.cpp
@@ -29,15 +29,13 @@ extern "C"
 namespace Systems {
     constexpr float maxPercent = 100.0F;
 
-    void windowCollision(std::size_t /*unused*/, std::size_t /*unused*/)
+    static void checkOutsideWindow(std::vector<std::size_t> ids)
     {
         std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
-        Registry &registry                                = Registry::getInstance();
+        Registry &registry = Registry::getInstance();
         Registry::components<Types::Position> arrPosition = registry.getComponents<Types::Position>();
         Registry::components<Types::CollisionRect> arrCollisionRect =
-            registry.getComponents<Types::CollisionRect>();
-        std::vector<std::size_t> ids = registry.getEntitiesByComponents(
-            {typeid(Types::Player), typeid(Types::Position), typeid(Types::CollisionRect)});
+                registry.getComponents<Types::CollisionRect>();
 
         for (std::size_t id : ids) {
             if (arrPosition[id].x < 0) {
@@ -53,6 +51,18 @@ namespace Systems {
                 arrPosition[id].y = maxPercent - arrCollisionRect[id].height;
             }
         }
+    }
+
+    void windowCollision(std::size_t /*unused*/, std::size_t /*unused*/)
+    {
+        Registry &registry = Registry::getInstance();
+        std::vector<std::size_t> ids = registry.getEntitiesByComponents(
+                {typeid(Types::Player), typeid(Types::Position), typeid(Types::CollisionRect)});
+        std::vector<std::size_t> idsOtherPlayer = registry.getEntitiesByComponents(
+                {typeid(Types::OtherPlayer), typeid(Types::Position), typeid(Types::CollisionRect)});
+
+        checkOutsideWindow(ids);
+        checkOutsideWindow(idsOtherPlayer);
     }
 
     static bool checkAllies(std::size_t fstId, std::size_t scdId)

--- a/src/ECS/Systems/Systems.cpp
+++ b/src/ECS/Systems/Systems.cpp
@@ -31,7 +31,6 @@ namespace Systems {
 
     static void checkOutsideWindow(std::vector<std::size_t> ids)
     {
-        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         Registry &registry = Registry::getInstance();
         Registry::components<Types::Position> arrPosition = registry.getComponents<Types::Position>();
         Registry::components<Types::CollisionRect> arrCollisionRect =
@@ -55,6 +54,7 @@ namespace Systems {
 
     void windowCollision(std::size_t /*unused*/, std::size_t /*unused*/)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         Registry &registry = Registry::getInstance();
         std::vector<std::size_t> ids = registry.getEntitiesByComponents(
                 {typeid(Types::Player), typeid(Types::Position), typeid(Types::CollisionRect)});
@@ -254,6 +254,7 @@ namespace Systems {
 
     void manageBoss(std::size_t managerId, std::size_t systemId)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         const float posToGo   = 65.0;
         const float bossSpeed = 0.2F;
         Registry::components<Types::Position> &arrPosition =
@@ -284,6 +285,7 @@ namespace Systems {
 
     void initWave(std::size_t managerId, std::size_t systemId)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         static std::size_t enemyNumber =
             Json::getInstance().getDataByVector({"wave", "nbrEnemy"}, JsonType::WAVE);
         const std::size_t spawnDelay = 2;

--- a/src/ECS/Systems/Systems.cpp
+++ b/src/ECS/Systems/Systems.cpp
@@ -31,10 +31,10 @@ namespace Systems {
 
     static void checkOutsideWindow(std::vector<std::size_t> ids)
     {
-        Registry &registry = Registry::getInstance();
+        Registry &registry                                = Registry::getInstance();
         Registry::components<Types::Position> arrPosition = registry.getComponents<Types::Position>();
         Registry::components<Types::CollisionRect> arrCollisionRect =
-                registry.getComponents<Types::CollisionRect>();
+            registry.getComponents<Types::CollisionRect>();
 
         for (std::size_t id : ids) {
             if (arrPosition[id].x < 0) {
@@ -55,11 +55,11 @@ namespace Systems {
     void windowCollision(std::size_t /*unused*/, std::size_t /*unused*/)
     {
         std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
-        Registry &registry = Registry::getInstance();
+        Registry &registry           = Registry::getInstance();
         std::vector<std::size_t> ids = registry.getEntitiesByComponents(
-                {typeid(Types::Player), typeid(Types::Position), typeid(Types::CollisionRect)});
+            {typeid(Types::Player), typeid(Types::Position), typeid(Types::CollisionRect)});
         std::vector<std::size_t> idsOtherPlayer = registry.getEntitiesByComponents(
-                {typeid(Types::OtherPlayer), typeid(Types::Position), typeid(Types::CollisionRect)});
+            {typeid(Types::OtherPlayer), typeid(Types::Position), typeid(Types::CollisionRect)});
 
         checkOutsideWindow(ids);
         checkOutsideWindow(idsOtherPlayer);
@@ -435,12 +435,13 @@ namespace Systems {
 
     void initPlayer(unsigned int constId, bool otherPlayer)
     {
-        JsonType playerType  = JsonType::DEFAULT_PLAYER;
+        JsonType playerType = JsonType::DEFAULT_PLAYER;
 
         Registry::getInstance().addEntity();
 
         Logger::info("player avant template");
-        Types::Dead deadComp = {Json::getInstance().getDataByVector<std::size_t>({"player", "deadTime"}, playerType)};
+        Types::Dead deadComp = {
+            Json::getInstance().getDataByVector<std::size_t>({"player", "deadTime"}, playerType)};
         struct health_s healthComp = {
             Json::getInstance().getDataByVector<int>({"player", "health"}, playerType)};
         Logger::info("player after template");

--- a/src/ECS/Systems/Systems.cpp
+++ b/src/ECS/Systems/Systems.cpp
@@ -199,14 +199,9 @@ namespace Systems {
             Json::getInstance().getDataByJsonType("enemy", jsonType);
 
         for (auto &elem : enemyData) {
-#ifdef CLIENT
-            std::size_t id = Registry::getInstance().addEntity();
-#else
             Registry::getInstance().addEntity();
-#endif
 
 #ifdef CLIENT
-
             Types::SpriteDatas enemy = {
                 Json::getInstance().getDataFromJson<std::string>(elem, "spritePath"),
                 Json::getInstance().getDataFromJson<float>(elem, "width"),
@@ -214,7 +209,7 @@ namespace Systems {
                 LayerType::DEFAULTLAYER,
                 0};
 
-            Types::Rect rect = Json::getInstance().getDataFromJson<Types::Rect>(elem, "rect");
+            auto rect = Json::getInstance().getDataFromJson<Types::Rect>(elem, "rect");
 
             nlohmann::basic_json<> animRectData =
                 Json::getInstance().getDataFromJson<nlohmann::basic_json<>>(elem, "animRect");
@@ -276,13 +271,13 @@ namespace Systems {
         for (auto &id : ids) {
             if (arrPosition[id].x <= posToGo && arrVelocity[id].speedY == 0) {
                 arrVelocity[id].speedX = 0;
-                arrVelocity[id].speedY = 0.2;
+                arrVelocity[id].speedY = static_cast<float>(0.2);
             }
             if (arrPosition[id].y < 0) {
                 arrVelocity[id].speedY = bossSpeed;
             }
             if (arrPosition[id].y + arrCollisonRect[id].height > maxPercent) {
-                arrVelocity[id].speedY = -bossSpeed;
+                arrVelocity[id].speedY -= bossSpeed;
             }
         }
     }
@@ -436,17 +431,17 @@ namespace Systems {
         }
     }
 
-    void initPlayer(JsonType playerType, unsigned int constId, bool otherPlayer)
+    void initPlayer(unsigned int constId, bool otherPlayer)
     {
-#ifdef CLIENT
-        std::size_t id = Registry::getInstance().addEntity();
-#else
-        Registry::getInstance().addEntity();
-#endif
+        JsonType playerType  = JsonType::DEFAULT_PLAYER;
 
-        Types::Dead deadComp = {Json::getInstance().getDataByVector({"player", "deadTime"}, playerType)};
+        Registry::getInstance().addEntity();
+
+        Logger::info("player avant template");
+        Types::Dead deadComp = {Json::getInstance().getDataByVector<std::size_t>({"player", "deadTime"}, playerType)};
         struct health_s healthComp = {
-            Json::getInstance().getDataByVector({"player", "health"}, playerType)};
+            Json::getInstance().getDataByVector<int>({"player", "health"}, playerType)};
+        Logger::info("player after template");
         Types::Damage damageComp = {Json::getInstance().getDataByVector({"player", "damage"}, playerType)};
 #ifdef CLIENT
         Types::SpriteDatas playerDatas(
@@ -498,11 +493,7 @@ namespace Systems {
 
     void createMissile(Types::Position &pos, Types::Missiles &typeOfMissile)
     {
-#ifdef CLIENT
-        std::size_t entityId = Registry::getInstance().addEntity();
-#else
         Registry::getInstance().addEntity();
-#endif
 
         constexpr float bulletWidth          = 5.0F;
         constexpr float bulletHeight         = 5.0F;

--- a/src/ECS/Systems/Systems.hpp
+++ b/src/ECS/Systems/Systems.hpp
@@ -26,6 +26,6 @@ namespace Systems {
     void deathChecker(std::size_t, std::size_t);
     void initWave(std::size_t managerId, std::size_t systemId);
     void createMissile(Types::Position &pos, Types::Missiles &typeOfMissile);
-    void initPlayer(JsonType playerType, unsigned int constId, bool otherPlayer = false);
+    void initPlayer(unsigned int constId, bool otherPlayer = false);
     std::vector<std::function<void(std::size_t, std::size_t)>> getECSSystems();
 } // namespace Systems

--- a/src/Nitwork/NitworkServer.cpp
+++ b/src/Nitwork/NitworkServer.cpp
@@ -133,6 +133,7 @@ namespace Nitwork {
     void
     NitworkServer::handleInitMsg(const std::any & /* unused */, boost::asio::ip::udp::endpoint &endpoint)
     {
+        std::lock_guard<std::mutex> lock(Registry::getInstance().mutex);
         if (_endpoints.size() >= _maxNbPlayer) {
             std::cerr << "Too many clients, can't add an other one" << std::endl;
             return;
@@ -172,7 +173,9 @@ namespace Nitwork {
             return;
         }
         addStarWaveMessage(endpoint, Types::Enemy::getEnemyNb());
-        Systems::SystemManagersDirector::getInstance().getSystemManager(0).addSystem(Systems::initWave);
+        auto &director = Systems::SystemManagersDirector::getInstance();
+        std::lock_guard<std::mutex> lock(director.mutex);
+        director.getSystemManager(0).addSystem(Systems::initWave);
     }
 
     void

--- a/src/Nitwork/NitworkServer.cpp
+++ b/src/Nitwork/NitworkServer.cpp
@@ -150,7 +150,7 @@ namespace Nitwork {
             .action = {.magick = NEW_ALLIE},
             .msg    = {.magick = MAGICK_NEW_ALLIE, .playerId = playerId}
         };
-        Systems::initPlayer(JsonType::DEFAULT_PLAYER, playerId, true);
+        Systems::initPlayer(playerId, true);
         sendNewAllie(playerId, packetMsgNewAllie, endpoint);
         for (const auto &[_, allieId] : _playersIds) {
             if (allieId == playerId) {

--- a/src/main_server.cpp
+++ b/src/main_server.cpp
@@ -56,11 +56,16 @@ int main(int ac, const char **av)
     if (!Nitwork::NitworkServer::getInstance().startServer(std::stoi(av[1]), std::stoi(av[2]))) {
         return EXIT_EPITECH;
     }
-    Systems::SystemManagersDirector::getInstance().addSystemManager(Systems::getECSSystems());
+    auto &director = Systems::SystemManagersDirector::getInstance();
+    std::unique_lock<std::mutex> lock(director.mutex);
+    director.addSystemManager(Systems::getECSSystems());
     signal(SIGINT, signalHandler);
 
+    lock.unlock();
     while (isRunning && Nitwork::NitworkServer::getInstance().isRunning()) {
-        Systems::SystemManagersDirector::getInstance().getSystemManager(0).updateSystems();
+        lock.lock();
+        director.getSystemManager(0).updateSystems();
+        lock.unlock();
     }
     Nitwork::NitworkServer::getInstance().stop();
     return 0;


### PR DESCRIPTION
<!-- This is a template message
     You will need to mark input boxes after clicking on
     create new pull request so just fill the blank.
     That means you don't need to touch the third categories
     because you fill mark them after pr creation
-->

<!-- Will be filled after creation -->
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Norm of the code has been respected

<!-- Will be filled after creation -->
* **In what state is your pull request?**
- [x] Ready to merge / Waiting a reviwer to see my work.
- [ ] Work In Progress (WIP) / My work is not finish but i want daily reviews. (Draft)
- [ ] CI Review / I want to see what the CI thinks of my work.
- [ ] Need feedback / Just to have feedback on what i produced. (May not be merged)

<!-- Will be filled after creation -->
* **What kind of change does this PR introduce?** (You can choose multiple)
- [x] Bug fix
- [ ] Feature request
- [ ] New / Updated documentation
- [ ] Testing CI ( Make the pull request in draft mode)

* **What is the current behavior?** (link an issue based on the kind of change this pr introduce)


* **What is the new behavior (if this is a feature change)?**


* **Other information**:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Enhanced thread safety across various functions to ensure smooth and reliable performance.
- Streamlined the process of updating system managers, improving the software's efficiency.
- Improved error handling in the `run()` function, increasing the software's robustness.

**New Feature:**
- Added new template functions to the `Json` class for more flexible data retrieval from JSON objects.

**Bug Fix:**
- Fixed potential data race issues in the `SystemManager` class by removing the usage of a mutex lock.
- Adjusted the initialization and usage of the `SystemManagersDirector` class to ensure proper synchronization and prevent data races.

**Note:** These changes primarily improve the software's performance and reliability. They may not result in noticeable changes for end-users but are crucial for maintaining a high-quality user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->